### PR TITLE
In startStandardExit() pass exitData.utxo_pos as a string

### DIFF
--- a/src/omg-wallet.js
+++ b/src/omg-wallet.js
@@ -208,7 +208,7 @@ async function startStandardExit () {
     const exitData = await childChain.getExitData(utxos[0])
 
     let receipt = await rootChain.startStandardExit(
-      exitData.utxo_pos,
+      exitData.utxo_pos.toString(),
       exitData.txbytes,
       exitData.proof,
       {


### PR DESCRIPTION
Different, clashing versions of BigNumber cause problems with automatic conversion.
We can pass exitData.utxo_pos as a string to avoid the issue