### PR TITLE
Remove redundant toString()

### DIFF
--- a/src/omg-wallet.js
+++ b/src/omg-wallet.js
@@ -164,7 +164,7 @@ async function childchainTransfer () {
     txBody.outputs.push({
       owner: fromAddr,
       currency: tokenContract,
-      amount: CHANGE_AMOUNT.toString()
+      amount: CHANGE_AMOUNT
     })
   }
 


### PR DESCRIPTION
remove toString on CHANGE_AMOUNT() which breaks transactions involving a large amount for CHANGE_AMOUNT.